### PR TITLE
Simplified check for successful response to only check for code "200"

### DIFF
--- a/src/BulkSmsService.php
+++ b/src/BulkSmsService.php
@@ -157,7 +157,7 @@ class BulkSmsService
      */
     public function validateResponse($response)
     {
-        if ($response->code !== '200 OK') {
+        if (substr($response->code, 0,3) !== '200') {
             throw new BulkSmsException('BulkSMS API responded with HTTP status code ' . $response->code);
         }
 


### PR DESCRIPTION
Migration of BulkSMS to newer APIs return http/2 headers, which in turn do NOT respond with "200 OK".

Expect a matching pull request for cURL library.

Thank you.